### PR TITLE
Add support for `script_class` attribute in resource headers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fernforestgames/godot-resource-parser",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fernforestgames/godot-resource-parser",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "bin": {
         "godot-resource-parser": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fernforestgames/godot-resource-parser",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Parser for Godot 4 .tscn and .tres files",
   "author": "Justin Spahr-Summers <justin@fernforestgames.com> (https://fernforestgames.com)",
   "license": "MIT",

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -108,6 +108,9 @@ export class Parser {
       if (attrs['uid'] !== undefined) {
         header.uid = attrs['uid'] as string
       }
+      if (attrs['script_class'] !== undefined) {
+        header.scriptClass = attrs['script_class'] as string
+      }
       return header
     } else {
       throw ParseSyntaxError.withContext(

--- a/src/types.ts
+++ b/src/types.ts
@@ -248,7 +248,7 @@ export interface GdSceneHeader {
 }
 
 /**
- * File header for resources: [gd_resource type="X" load_steps=Y format=Z uid="..."]
+ * File header for resources: [gd_resource type="X" load_steps=Y format=Z uid="..." script_class="..."]
  */
 export interface GdResourceHeader {
   type: 'gd_resource'
@@ -256,6 +256,7 @@ export interface GdResourceHeader {
   loadSteps?: number
   format: number
   uid?: string
+  scriptClass?: string
 }
 
 export type FileHeader = GdSceneHeader | GdResourceHeader

--- a/tests/fixtures/player_data.tres
+++ b/tests/fixtures/player_data.tres
@@ -1,0 +1,15 @@
+[gd_resource type="Resource" script_class="CustomData" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://custom_data.gd" id="1_a2b3c"]
+
+[resource]
+script = ExtResource("1_a2b3c")
+player_name = "Hero"
+score = 1500
+level = 5
+inventory = Array[String](["sword", "shield", "potion"])
+stats = {
+"health": 100,
+"mana": 50,
+"strength": 15
+}

--- a/tests/player_data.test.ts
+++ b/tests/player_data.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from '@jest/globals'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import { parseResource } from '../src/parser.js'
+import { isGodotResource } from '../src/types.js'
+
+describe('Player data resource parsing', () => {
+  test('parses player_data.tres with script_class attribute', () => {
+    const content = readFileSync(join(__dirname, 'fixtures', 'player_data.tres'), 'utf-8')
+    const result = parseResource(content)
+
+    expect(isGodotResource(result)).toBe(true)
+
+    // Check header with script_class
+    expect(result.header.type).toBe('gd_resource')
+    expect(result.header.resourceType).toBe('Resource')
+    expect(result.header.scriptClass).toBe('CustomData')
+    expect(result.header.format).toBe(3)
+    expect(result.header.loadSteps).toBe(2)
+
+    // Check ext_resource
+    expect(result.extResources).toHaveLength(1)
+    expect(result.extResources[0]).toEqual({
+      type: 'Script',
+      path: 'res://custom_data.gd',
+      id: '1_a2b3c',
+    })
+
+    // Check resource properties
+    expect(result.resource).toBeDefined()
+    expect(result.resource?.properties['player_name']).toBe('Hero')
+    expect(result.resource?.properties['score']).toBe(1500)
+    expect(result.resource?.properties['level']).toBe(5)
+
+    // Check typed array
+    expect(result.resource?.properties['inventory']).toEqual({
+      type: 'array',
+      elementType: 'String',
+      values: ['sword', 'shield', 'potion'],
+    })
+
+    // Check dictionary
+    expect(result.resource?.properties['stats']).toEqual({
+      health: 100,
+      mana: 50,
+      strength: 15,
+    })
+
+    // Check script reference
+    expect(result.resource?.properties['script']).toEqual({
+      type: 'ExtResource',
+      id: '1_a2b3c',
+    })
+  })
+})


### PR DESCRIPTION
Godot resources can specify a custom script_class in their header:

```
[gd_resource type="Resource" script_class="CustomData" ...]
```

This attribute is now parsed and exposed via the `scriptClass` field in `GdResourceHeader`.